### PR TITLE
Cache bundle and pass to rollup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'events';
 import * as fs from 'fs';
 import { sequence } from './utils/promise.js';
+import { assign } from './utils/object.js';
 import { name, version } from '../package.json';
 import checkVersion from './utils/checkVersion.js';
 
@@ -57,6 +58,7 @@ export default function watch ( rollup, options ) {
 			let watching = false;
 
 			let timeout;
+			let cache;
 
 			function triggerRebuild () {
 				clearTimeout( timeout );
@@ -75,13 +77,17 @@ export default function watch ( rollup, options ) {
 
 				let start = Date.now();
 				let initial = !watching;
+				let opts = assign( {}, options, cache ? { cache } : {});
 
 				emitter.emit( 'event', { code: 'BUILD_START' });
 
 				building = true;
 
-				return rollup.rollup( options )
+				return rollup.rollup( opts )
 					.then( bundle => {
+						// Save off bundle for re-use later
+						cache = bundle;
+
 						bundle.modules.forEach( module => {
 							const id = module.id;
 

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,0 +1,9 @@
+export function assign ( target, ...sources ) {
+	sources.forEach( source => {
+		for ( let key in source ) {
+			if ( source.hasOwnProperty( key ) ) target[ key ] = source[ key ];
+		}
+	});
+
+	return target;
+}


### PR DESCRIPTION
Fixes #8 

Caches the generated bundle after `rollup` runs and then pass it to all subsequent `rollup` invocations to try and speed things up.

Unfortunately due to rollup/rollup#723 it's not as fast as it seems like it should be. Cuts ~0.5s off my build times (3-4s normally). Not much, but I'll take it.

I copied the `Object.assign` polyfill from rollup proper so I wasn't modifying the `options` object passed in, I don't know if that's the right approach though?
