### PR TITLE
Toggle watching flag so initial flag is correct

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,9 @@ export default function watch ( rollup, options ) {
 							}
 						});
 
+						// Now we're watching
+						watching = true;
+
 						if ( options.targets ) {
 							return sequence( options.targets, target => {
 								const mergedOptions = Object.assign( {}, options, target );


### PR DESCRIPTION
Currently every single `BUILD_END` event has the `initial` property set to `true`. That's not very helpful, so I did some digging.

It turns out it's because the `initial` value being passed along is calculated every time bundling starts by negating the `watching` value. So far, makes sense. The problem is that `watching` is initialized to false (reasonable) but never set to `true` once rollup-watch is actually watching things.

So here's my best-guess at the right place to set `watching` to true. Every build after the first now correctly has `initial : false` set in the `BUILD_END` event.
