### PR TITLE
Switch to chokidar for file watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/rollup-watch.cjs.js",
   "jsnext:main": "dist/rollup-watch.es6.js",
   "files": [
-    "src", "dist", "README.md"
+    "src",
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "test": "mocha",
@@ -37,6 +39,7 @@
     "rollup-plugin-json": "^2.0.0"
   },
   "dependencies": {
+    "chokidar": "^1.6.0",
     "semver": "^5.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,42 +1,11 @@
 import EventEmitter from 'events';
-import * as fs from 'fs';
+import chokidar from 'chokidar';
 import { sequence } from './utils/promise.js';
 import { assign } from './utils/object.js';
 import { name, version } from '../package.json';
 import checkVersion from './utils/checkVersion.js';
 
-const opts = { encoding: 'utf-8', persistent: true };
-
-class FileWatcher {
-	constructor ( file, data, callback, dispose ) {
-		try {
-			const fsWatcher = fs.watch( file, opts, event => {
-				if ( event === 'rename' ) {
-					fsWatcher.close();
-					dispose();
-					callback();
-				} else {
-					// this is necessary because we get duplicate events...
-					const contents = fs.readFileSync( file, 'utf-8' );
-					if ( contents !== data ) {
-						data = contents;
-						callback();
-					}
-				}
-			});
-
-			this.fileExists = true;
-		} catch ( err ) {
-			if ( err.code === 'ENOENT' ) {
-				// can't watch files that don't exist (e.g. injected
-				// by plugins somehow)
-				this.fileExists = false;
-			} else {
-				throw err;
-			}
-		}
-	}
-}
+const watcher = chokidar.watch();
 
 export default function watch ( rollup, options ) {
 	const emitter = new EventEmitter();
@@ -51,8 +20,6 @@ export default function watch ( rollup, options ) {
 			}
 		})
 		.then( () => {
-			let filewatchers = new Map();
-
 			let rebuildScheduled = false;
 			let building = false;
 			let watching = false;
@@ -94,13 +61,7 @@ export default function watch ( rollup, options ) {
 							// skip plugin helper modules
 							if ( /\0/.test( id ) ) return;
 
-							if ( !filewatchers.has( id ) ) {
-								const watcher = new FileWatcher( id, module.originalCode, triggerRebuild, () => {
-									filewatchers.delete( id );
-								});
-
-								if ( watcher.fileExists ) filewatchers.set( id, watcher );
-							}
+							watcher.add(id);
 						});
 
 						if ( options.targets ) {
@@ -131,6 +92,8 @@ export default function watch ( rollup, options ) {
 			}
 
 			build();
+
+			watcher.on('change', () => triggerRebuild());
 		});
 
 	return emitter;


### PR DESCRIPTION
Noticed that `rollup --watch` was getting into an infinite loop pretty frequently. This PR replaces `fs.watch` with [gaze](https://github.com/shama/gaze), which seems to be much more reliable (and also greatly simplifies the code).
