### PR TITLE
make require-relative a dependency not a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
     "url": "https://github.com/rollup/rollup-watch/issues"
   },
   "homepage": "https://github.com/rollup/rollup-watch#readme",
-  "dependencies": {},
+  "dependencies": {
+    "require-relative": "0.8.7"
+  },
   "devDependencies": {
     "eslint": "^3.12.2",
     "mocha": "^3.2.0",
-    "require-relative": "0.8.7",
     "rollup": "^0.39.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^7.0.0",


### PR DESCRIPTION
I wrongly added require-relative as a dev dependency, but then chokidar
won't be used since require-relative won't be available for regular
usage like npm install.