### PR TITLE
On error, continue to monitor all the files / modules found after the…

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,38 @@ describe( 'rollup-watch', () => {
 		});
 	});
 
+	it( 'recovers from an error even when erroring file was "renamed" (#38)', () => {
+		return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
+			const watcher = watch( rollup, {
+				entry: 'test/_tmp/input/main.js',
+				dest: 'test/_tmp/output/bundle.js',
+				format: 'cjs'
+			});
+
+			return sequence( watcher, [
+				'BUILD_START',
+				'BUILD_END',
+				() => {
+					assert.equal( run( './_tmp/output/bundle.js' ), 42 );
+					sander.unlinkSync( 'test/_tmp/input/main.js' );
+					sander.writeFileSync( 'test/_tmp/input/main.js', 'export nope;' );
+				},
+				'BUILD_START',
+				'ERROR',
+				() => {
+					sander.unlinkSync( 'test/_tmp/input/main.js' );
+					sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
+				},
+				'BUILD_START',
+				'BUILD_END',
+				() => {
+					assert.equal( run( './_tmp/output/bundle.js' ), 43 );
+					watcher.close();
+				}
+			]);
+		});
+	});
+
 	it( 'refuses to watch the output file (#15)', () => {
 		return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
 			const watcher = watch( rollup, {


### PR DESCRIPTION
… last successful rollup. Fixes #38.

The issue is that (at least on my Ubuntu) saving a file from a text-editor causes a "rename" event which causes the fileWatcher to stop watching the file (https://github.com/rollup/rollup-watch/blob/master/src/index.js#L20) in addition to kicking off a rollup rebuild.

Normally this is fine because the rollup completes and rollup-watch starts watching all the files again (https://github.com/rollup/rollup-watch/blob/master/src/index.js#L99), but in the case of an error it never gets there, so never starts watching again, so the file with the error is no longer watched, and fixing the error doesn't trigger a rebuild.

This PR uses the cache from the last successful rebuild to re-add filewatchers to all those files.

I added a test you can run (against the unpatched code) to see the error, then apply my patch to see it is fixed.

Tests and lint are passing.