### PR TITLE
Fixed error when importing path module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import relative from 'require-relative';
-import * as path from 'path';
+import path from 'path';
 import * as fs from 'fs';
 import { sequence } from './utils/promise.js';
 


### PR DESCRIPTION
Fix for #45. All I've done is change `import * as path from 'path'` to `import path from 'path'` in index.js, as suggested by @AdamHerrmann. I've tested it on a real project, and it seems to work.