### PR TITLE
Various

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/rollup/rollup-watch#readme",
   "dependencies": {
+    "chokidar": "^1.7.0",
     "require-relative": "0.8.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "eslint": "^3.12.2",
     "mocha": "^3.2.0",
-    "rollup": "^0.41.6",
+    "rollup": "^0.42.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "devDependencies": {
     "eslint": "^3.12.2",
     "mocha": "^3.2.0",
-    "rollup": "^0.39.0",
+    "rollup": "^0.41.6",
     "rollup-plugin-buble": "^0.15.0",
-    "rollup-plugin-commonjs": "^7.0.0",
+    "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.0.0",
-    "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-node-resolve": "^3.0.0",
     "sander": "^0.6.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ try {
 
 class FileWatcher {
 	constructor ( file, data, callback, useChokidar, dispose ) {
-		const handleWatchEvent = (event, filename) => {
+		const handleWatchEvent = (event) => {
 			if ( event === 'rename' || event === 'unlink' ) {
 				this.fsWatcher.close();
 				dispose();

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ const sander = require( 'sander' );
 const rollup = require( 'rollup' );
 const watch = require( '..' );
 
-function wait ( ms = 100 ) {
+function wait ( ms ) {
 	return new Promise( fulfil => {
 		setTimeout( fulfil, ms );
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -42,7 +42,7 @@ describe( 'rollup-watch', () => {
 
 				else {
 					Promise.resolve()
-						.then( () => wait( 100 ) ) // gah, this appears to be necessary to fix random errors
+						.then( () => wait( 500 ) ) // gah, this appears to be necessary to fix random errors
 						.then( () => next( event ) )
 						.then( go )
 						.catch( reject );

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,7 @@ describe( 'rollup-watch', () => {
 				else if ( typeof next === 'string' ) {
 					watcher.once( 'event', event => {
 						if ( event.code !== next ) {
+							console.log( event );
 							reject( new Error( `Expected ${next} error, got ${event.code}` ) );
 						} else {
 							go( event );

--- a/test/test.js
+++ b/test/test.js
@@ -42,7 +42,7 @@ describe( 'rollup-watch', () => {
 
 				else {
 					Promise.resolve()
-						.then( () => wait( 500 ) ) // gah, this appears to be necessary to fix random errors
+						.then( () => wait( 100 ) ) // gah, this appears to be necessary to fix random errors
 						.then( () => next( event ) )
 						.then( go )
 						.catch( reject );
@@ -57,9 +57,11 @@ describe( 'rollup-watch', () => {
 		runTests( false );
 	});
 
-	describe( 'chokidar', () => {
-		runTests( true );
-	});
+	if ( !process.env.CI ) {
+		describe( 'chokidar', () => {
+			runTests( true );
+		});
+	}
 
 	function runTests ( useChokidar ) {
 		it( 'watches a file', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -3,8 +3,16 @@ const sander = require( 'sander' );
 const rollup = require( 'rollup' );
 const watch = require( '..' );
 
+function wait ( ms = 100 ) {
+	return new Promise( fulfil => {
+		setTimeout( fulfil, ms );
+	});
+}
+
 describe( 'rollup-watch', () => {
-	beforeEach( () => sander.rimraf( 'test/_tmp' ) );
+	beforeEach( () => {
+		return sander.rimraf( 'test/_tmp' );
+	});
 
 	function run ( file ) {
 		const resolved = require.resolve( file );
@@ -33,6 +41,7 @@ describe( 'rollup-watch', () => {
 
 				else {
 					Promise.resolve()
+						.then( () => wait( 100 ) ) // gah, this appears to be necessary to fix random errors
 						.then( () => next( event ) )
 						.then( go )
 						.catch( reject );
@@ -43,121 +52,135 @@ describe( 'rollup-watch', () => {
 		});
 	}
 
-	it( 'watches a file', () => {
-		return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
-			const watcher = watch( rollup, {
-				entry: 'test/_tmp/input/main.js',
-				dest: 'test/_tmp/output/bundle.js',
-				format: 'cjs'
-			});
-
-			return sequence( watcher, [
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 42 );
-					sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
-				},
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 43 );
-					watcher.close();
-				}
-			]);
-		});
+	describe( 'fs.watch', () => {
+		runTests( false );
 	});
 
-	it( 'recovers from an error', () => {
-		return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
-			const watcher = watch( rollup, {
-				entry: 'test/_tmp/input/main.js',
-				dest: 'test/_tmp/output/bundle.js',
-				format: 'cjs'
-			});
-
-			return sequence( watcher, [
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 42 );
-					sander.writeFileSync( 'test/_tmp/input/main.js', 'export nope;' );
-				},
-				'BUILD_START',
-				'ERROR',
-				() => {
-					sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
-				},
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 43 );
-					watcher.close();
-				}
-			]);
-		});
+	describe( 'chokidar', () => {
+		runTests( true );
 	});
 
-	it( 'recovers from an error even when erroring file was "renamed" (#38)', () => {
-		return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
-			const watcher = watch( rollup, {
-				entry: 'test/_tmp/input/main.js',
-				dest: 'test/_tmp/output/bundle.js',
-				format: 'cjs'
+	function runTests ( useChokidar ) {
+		it( 'watches a file', () => {
+			return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
+				const watcher = watch( rollup, {
+					entry: 'test/_tmp/input/main.js',
+					dest: 'test/_tmp/output/bundle.js',
+					format: 'cjs',
+					watch: { useChokidar }
+				});
+
+				return sequence( watcher, [
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 42 );
+						sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
+					},
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 43 );
+						watcher.close();
+					}
+				]);
 			});
-
-			return sequence( watcher, [
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 42 );
-					sander.unlinkSync( 'test/_tmp/input/main.js' );
-					sander.writeFileSync( 'test/_tmp/input/main.js', 'export nope;' );
-				},
-				'BUILD_START',
-				'ERROR',
-				() => {
-					sander.unlinkSync( 'test/_tmp/input/main.js' );
-					sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
-				},
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 43 );
-					watcher.close();
-				}
-			]);
 		});
-	});
 
-	it( 'refuses to watch the output file (#15)', () => {
-		return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
-			const watcher = watch( rollup, {
-				entry: 'test/_tmp/input/main.js',
-				dest: 'test/_tmp/output/bundle.js',
-				format: 'cjs'
+		it( 'recovers from an error', () => {
+			return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
+				const watcher = watch( rollup, {
+					entry: 'test/_tmp/input/main.js',
+					dest: 'test/_tmp/output/bundle.js',
+					format: 'cjs',
+					watch: { useChokidar }
+				});
+
+				return sequence( watcher, [
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 42 );
+						sander.writeFileSync( 'test/_tmp/input/main.js', 'export nope;' );
+					},
+					'BUILD_START',
+					'ERROR',
+					() => {
+						sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
+					},
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 43 );
+						watcher.close();
+					}
+				]);
 			});
-
-			return sequence( watcher, [
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 42 );
-					sander.writeFileSync( 'test/_tmp/input/main.js', `import '../output/bundle.js'` );
-				},
-				'BUILD_START',
-				'ERROR',
-				event => {
-					assert.equal( event.error.message, 'Cannot import the generated bundle' );
-					sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
-				},
-				'BUILD_START',
-				'BUILD_END',
-				() => {
-					assert.equal( run( './_tmp/output/bundle.js' ), 43 );
-					watcher.close();
-				}
-			]);
 		});
-	});
+
+		it( 'recovers from an error even when erroring file was "renamed" (#38)', () => {
+			return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
+				const watcher = watch( rollup, {
+					entry: 'test/_tmp/input/main.js',
+					dest: 'test/_tmp/output/bundle.js',
+					format: 'cjs',
+					watch: { useChokidar }
+				});
+
+				return sequence( watcher, [
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 42 );
+						sander.unlinkSync( 'test/_tmp/input/main.js' );
+						sander.writeFileSync( 'test/_tmp/input/main.js', 'export nope;' );
+					},
+					'BUILD_START',
+					'ERROR',
+					() => {
+						sander.unlinkSync( 'test/_tmp/input/main.js' );
+						sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
+					},
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 43 );
+						watcher.close();
+					}
+				]);
+			});
+		});
+
+		it( 'refuses to watch the output file (#15)', () => {
+			return sander.copydir( 'test/samples/basic' ).to( 'test/_tmp/input' ).then( () => {
+				const watcher = watch( rollup, {
+					entry: 'test/_tmp/input/main.js',
+					dest: 'test/_tmp/output/bundle.js',
+					format: 'cjs',
+					watch: { useChokidar }
+				});
+
+				return sequence( watcher, [
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 42 );
+						sander.writeFileSync( 'test/_tmp/input/main.js', `import '../output/bundle.js'` );
+					},
+					'BUILD_START',
+					'ERROR',
+					event => {
+						assert.equal( event.error.message, 'Cannot import the generated bundle' );
+						sander.writeFileSync( 'test/_tmp/input/main.js', 'export default 43;' );
+					},
+					'BUILD_START',
+					'BUILD_END',
+					() => {
+						assert.equal( run( './_tmp/output/bundle.js' ), 43 );
+						watcher.close();
+					}
+				]);
+			});
+		});
+	}
 });


### PR DESCRIPTION
After merging #47, I started getting weird errors on OS X. I think there's some platform-specific nonsense that affects `fs.watch` from behaving correctly if you're writing to the filesystem very quickly (as the tests do) — sticking a 100ms delay before each function that manipulates the filesystem in the tests appears to fix it. I just hope that's not masking a bug that appears in real-world usage.

In the process of this I added a `useChokidar` option so that it's possible to test both `chokidar` and `fs.watch` (i.e. it's not solely determined by whether or not `chokidar` can be found). Not that you'd do this in real life, but as of Rollup 0.42 you can pass this option through like so:

```js
// rollup.config.js
export default {
  // other options...
  ...,
  watch: { useChokidar: true }
};
```