### PR TITLE
Make chokidar configurable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,15 @@ class FileWatcher {
 		};
 
 		try {
-			if (useChokidar)
-				this.fsWatcher = chokidar.watch(file, { ignoreInitial: true }).on('all', handleWatchEvent);
-			else
+			if (useChokidar) {
+				const chokidarOptions = Object.assign(
+					typeof useChokidar === 'object' ? useChokidar : {},
+					{ ignoreInitial: true }
+				);
+				this.fsWatcher = chokidar.watch(file, chokidarOptions).on('all', handleWatchEvent);
+			} else {
 				this.fsWatcher = fs.watch( file, opts, handleWatchEvent);
+			}
 
 			this.fileExists = true;
 		} catch ( err ) {


### PR DESCRIPTION
I use chokidar rather than fs.watch because chokidar has many options to fit various environments.

For example, I write codes over sftp and run rollup and a server on EC2, the destination of sftp. With default options, chokidar emits the "change" events before the end of sftp transfer.
So I often use [`awaitWriteFinish.stabilityThreshold`](https://www.npmjs.com/package/chokidar#performance) to wait until the file size get stable.

I'll be happy if rollup-watch makes chokidar configurable.