### PR TITLE
Activate stdin handler processing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,8 @@ export default function watch ( rollup, options ) {
 
 	// in case we ever support stdin!
 	process.stdin.on('end', close);
+	// Activate handler processing on stdin so `close` will be called properly
+	process.stdin.resume();
 
 	return watcher;
 }


### PR DESCRIPTION
The `close` handler when `stdin` is `end`ed is not being called.  Calling `resume()` on `process.stdin` will enable that handler so it will be called properly.  It should 'probably' be called earlier in the program, perhaps at the very start, but if it spools up fast enough it should not matter, and this is the same place similar code in other projects places it as well.

Properly fixes #30